### PR TITLE
Redundant raise error message was removed in end point 

### DIFF
--- a/main.py
+++ b/main.py
@@ -138,8 +138,7 @@ async def medicalCollegesByCity(city: str or None = None):
         raise HTTPException(
             status_code=404, detail='Some error occured, please try again')
 
-        raise HTTPException(
-            status_code=404, detail='Some error occured, please try again')
+
 
 
 @app.get('/management_colleges')


### PR DESCRIPTION
### Before Edit
There were two raise error in `@app.get('/medical_colleges/city={city}')`  api hence it was increasing its line of code .
### After Edit
Removed extra raise error in api and line of code is reduced and it is readable now.
Can you have a look @nikhil25803 ?
