### PR TITLE
Comma punctuation mark not added

### DIFF
--- a/data/allEngineeringColleges.json
+++ b/data/allEngineeringColleges.json
@@ -6324,7 +6324,7 @@
         "name": "P D Pandya Institute Of Computer Application",
         "city": "Ahmedabad",
         "state": "Gujarat"
-    }
+    },
   {
         "name": "Himalayan Group of Computer Application",
         "city": "Lucknow",


### PR DESCRIPTION
### Before
Comma punctuation was not added in allEngineeringColleges.json resulting in error because it was not supported in json
### After 
Added comma in punctuation mark so that now json structure doesn't give any error
@nikhil25803  can you have a look through it .